### PR TITLE
Added IE11 support to the Carousel 2 example

### DIFF
--- a/_posts/examples/2010-12-06-carousel-02-dynamic.html
+++ b/_posts/examples/2010-12-06-carousel-02-dynamic.html
@@ -74,29 +74,7 @@ category: examples
   <h1>{{ page.title }}</h1>
 
   <section class="container">
-    <div class=" panels-backface-invisible" style="transform: translateZ(-261px) rotateX(-270deg);-ms-transform: rotateX(270deg) translateZ(0px);" id="carousel">
-      <figure style="opacity: 1; background-color: rgba(255, 0, 0, 0.8); transform: rotateX(0deg) translateZ(261px);-ms-transform: rotateX(0deg) translateZ(261px); ">1</figure>
-      <figure style="opacity: 1; background-color: rgba(255, 127, 0, 0.8); transform: rotateX(30deg) translateZ(261px);-ms-transform: rotateX(30deg) translateZ(261px);">2</figure>
-      <figure style="opacity: 1; background-color: rgba(255, 255, 0, 0.8); transform: rotateX(60deg) translateZ(261px);-ms-transform: rotateX(60deg) translateZ(261px);">3</figure>
-      <figure style="opacity: 1; background-color: rgba(127, 255, 0, 0.8); transform: rotateX(90deg) translateZ(261px);-ms-transform: rotateX(90deg) translateZ(261px);">4</figure>
-      <figure style="opacity: 1; background-color: rgba(0, 255, 0, 0.8); transform: rotateX(120deg) translateZ(261px);-ms-transform: rotateX(120deg) translateZ(261px);">5</figure>
-      <figure style="opacity: 1; background-color: rgba(0, 255, 127, 0.8); transform: rotateX(150deg) translateZ(261px);-ms-transform: rotateX(150deg) translateZ(261px);">6</figure>
-      <figure style="opacity: 1; background-color: rgba(0, 255, 254, 0.8); transform: rotateX(180deg) translateZ(261px);-ms-transform: rotateX(180deg) translateZ(261px);">7</figure>
-      <figure style="opacity: 1; background-color: rgba(0, 127, 255, 0.8); transform: rotateX(210deg) translateZ(261px);-ms-transform: rotateX(210deg) translateZ(261px);">8</figure>
-      <figure style="opacity: 1; background-color: rgba(0, 0, 255, 0.8); transform: rotateX(240deg) translateZ(261px);-ms-transform: rotateX(240deg) translateZ(261px);">9</figure>
-      <figure style="opacity: 1; transform: rotateX(270deg) translateZ(261px);-ms-transform: rotateX(270deg) translateZ(261px); background-color: rgba(127, 0, 255, 0.8);">10</figure>
-      <figure style="opacity: 1; transform: rotateX(300deg) translateZ(261px);-ms-transform: rotateX(300deg) translateZ(261px); background-color: rgba(254, 0, 255, 0.8);">11</figure>
-      <figure style="opacity: 1; transform: rotateX(330deg) translateZ(261px);-ms-transform: rotateX(330deg) translateZ(261px); background-color: rgba(255, 0, 127, 0.8);">12</figure>
-      <figure style="opacity: 0; transform: none;">13</figure>
-      <figure style="opacity: 0; transform: none;">14</figure>
-      <figure style="opacity: 0; transform: none;">15</figure>
-      <figure style="opacity: 0; transform: none;">16</figure>
-      <figure style="opacity: 0; transform: none;">17</figure>
-      <figure style="opacity: 0; transform: none;">18</figure>
-      <figure style="opacity: 0; transform: none;">19</figure>
-      <figure style="opacity: 0; transform: none;">20</figure>
-    </div>
-    <!-- <div id="carousel">
+    <div id="carousel">
       <figure>1</figure>
       <figure>2</figure>
       <figure>3</figure>
@@ -117,7 +95,7 @@ category: examples
       <figure>18</figure>
       <figure>19</figure>
       <figure>20</figure>
-    </div> -->
+    </div>
   </section>
 
   <section id="options">

--- a/_posts/examples/2010-12-06-carousel-02-dynamic.html
+++ b/_posts/examples/2010-12-06-carousel-02-dynamic.html
@@ -15,6 +15,7 @@ category: examples
       -webkit-perspective: 1100px;
          -moz-perspective: 1100px;
            -o-perspective: 1100px;
+          -ms-perspective: 1100px;
               perspective: 1100px;
     }
 
@@ -73,7 +74,29 @@ category: examples
   <h1>{{ page.title }}</h1>
 
   <section class="container">
-    <div id="carousel">
+    <div class=" panels-backface-invisible" style="transform: translateZ(-261px) rotateX(-270deg);-ms-transform: rotateX(270deg) translateZ(0px);" id="carousel">
+      <figure style="opacity: 1; background-color: rgba(255, 0, 0, 0.8); transform: rotateX(0deg) translateZ(261px);-ms-transform: rotateX(0deg) translateZ(261px); ">1</figure>
+      <figure style="opacity: 1; background-color: rgba(255, 127, 0, 0.8); transform: rotateX(30deg) translateZ(261px);-ms-transform: rotateX(30deg) translateZ(261px);">2</figure>
+      <figure style="opacity: 1; background-color: rgba(255, 255, 0, 0.8); transform: rotateX(60deg) translateZ(261px);-ms-transform: rotateX(60deg) translateZ(261px);">3</figure>
+      <figure style="opacity: 1; background-color: rgba(127, 255, 0, 0.8); transform: rotateX(90deg) translateZ(261px);-ms-transform: rotateX(90deg) translateZ(261px);">4</figure>
+      <figure style="opacity: 1; background-color: rgba(0, 255, 0, 0.8); transform: rotateX(120deg) translateZ(261px);-ms-transform: rotateX(120deg) translateZ(261px);">5</figure>
+      <figure style="opacity: 1; background-color: rgba(0, 255, 127, 0.8); transform: rotateX(150deg) translateZ(261px);-ms-transform: rotateX(150deg) translateZ(261px);">6</figure>
+      <figure style="opacity: 1; background-color: rgba(0, 255, 254, 0.8); transform: rotateX(180deg) translateZ(261px);-ms-transform: rotateX(180deg) translateZ(261px);">7</figure>
+      <figure style="opacity: 1; background-color: rgba(0, 127, 255, 0.8); transform: rotateX(210deg) translateZ(261px);-ms-transform: rotateX(210deg) translateZ(261px);">8</figure>
+      <figure style="opacity: 1; background-color: rgba(0, 0, 255, 0.8); transform: rotateX(240deg) translateZ(261px);-ms-transform: rotateX(240deg) translateZ(261px);">9</figure>
+      <figure style="opacity: 1; transform: rotateX(270deg) translateZ(261px);-ms-transform: rotateX(270deg) translateZ(261px); background-color: rgba(127, 0, 255, 0.8);">10</figure>
+      <figure style="opacity: 1; transform: rotateX(300deg) translateZ(261px);-ms-transform: rotateX(300deg) translateZ(261px); background-color: rgba(254, 0, 255, 0.8);">11</figure>
+      <figure style="opacity: 1; transform: rotateX(330deg) translateZ(261px);-ms-transform: rotateX(330deg) translateZ(261px); background-color: rgba(255, 0, 127, 0.8);">12</figure>
+      <figure style="opacity: 0; transform: none;">13</figure>
+      <figure style="opacity: 0; transform: none;">14</figure>
+      <figure style="opacity: 0; transform: none;">15</figure>
+      <figure style="opacity: 0; transform: none;">16</figure>
+      <figure style="opacity: 0; transform: none;">17</figure>
+      <figure style="opacity: 0; transform: none;">18</figure>
+      <figure style="opacity: 0; transform: none;">19</figure>
+      <figure style="opacity: 0; transform: none;">20</figure>
+    </div>
+    <!-- <div id="carousel">
       <figure>1</figure>
       <figure>2</figure>
       <figure>3</figure>
@@ -94,7 +117,7 @@ category: examples
       <figure>18</figure>
       <figure>19</figure>
       <figure>20</figure>
-    </div>
+    </div> -->
   </section>
 
   <section id="options">
@@ -153,6 +176,14 @@ category: examples
         panel.style.backgroundColor = 'hsla(' + angle + ', 100%, 50%, 0.8)';
         // rotate panel, then push it out in 3D space
         panel.style[ transformProp ] = this.rotateFn + '(' + angle + 'deg) translateZ(' + this.radius + 'px)';
+        panel.style['-ms-transform'] = 'translateZ(0px)';// + this.rotateFn + '(-' + this.rotation + 'deg)';
+
+        for (var idx = 0; idx < panel.children.length; idx++) {
+            var child = panel.children[idx];
+            //child.style['backface-visibility'] = 'visible';
+            child.style['transform-origin'] = '50% 50%';
+            child.style['-ms-transform'] = 'perspective(0px) ' + this.rotateFn + '(-' + (this.rotation + (this.theta * idx)) + 'deg) translateZ(' + this.radius + 'px)';
+        }
       }
 
       // hide other panels
@@ -173,6 +204,14 @@ category: examples
       // push the carousel back in 3D space,
       // and rotate it
       this.element.style[ transformProp ] = 'translateZ(-' + this.radius + 'px) ' + this.rotateFn + '(' + this.rotation + 'deg)';
+      this.element.style['-ms-transform'] = 'translateZ(0px)';// + this.rotateFn + '(-' + this.rotation + 'deg)';
+
+      for (var idx = 0; idx < this.element.children.length; idx++) {
+          var child = this.element.children[idx];
+          //child.style['backface-visibility'] = 'hidden';//visible
+          child.style['transform-origin'] = '50% 50%';
+          child.style['-ms-transform'] = 'perspective(0px) ' + this.rotateFn + '(' + (this.rotation + (this.theta * idx)) + 'deg) translateZ(' + this.radius + 'px)';
+      }
     };
 
 


### PR DESCRIPTION
Sorry about the other pull request, I fixed the commit.  Now it is only going to modify the files that actually changed.

I added functionality to the Carousel 2 example which allow your carousel to work in IE11. There is still an issue w/ the backface visibility, but if it is toggled off, it works as expected.  I tested in IE10, but that did not work at all for me.

Thanks for your examples.
