### PR TITLE
Style margin to 0 on figure elements

### DIFF
--- a/_posts/docs/2010-12-04-card-flip.md
+++ b/_posts/docs/2010-12-04-card-flip.md
@@ -59,6 +59,7 @@ To position the faces in 3D space, we'll need to reset their positions in 2D wit
 {% highlight css %}
 
 #card figure {
+  margin: 0;
   display: block;
   position: absolute;
   width: 100%;

--- a/_posts/docs/2010-12-05-cube.md
+++ b/_posts/docs/2010-12-05-cube.md
@@ -44,6 +44,7 @@ Basic position and size styles set the 6 faces on top of one another in the cont
 }
 
 #cube figure {
+  margin: 0;
   width: 196px;
   height: 196px;
   display: block;

--- a/_posts/docs/2010-12-06-rectangular-prism.md
+++ b/_posts/docs/2010-12-06-rectangular-prism.md
@@ -33,6 +33,7 @@ Now, to position the faces. Each set of faces will need their own sizes. The sma
 {% highlight css %}
 
 #box figure {
+  margin: 0;
   display: block;
   position: absolute;
   border: 2px solid black;

--- a/_posts/docs/2010-12-07-carousel.md
+++ b/_posts/docs/2010-12-07-carousel.md
@@ -47,6 +47,7 @@ Now apply basic layout styles. Let's give each panel of the `#carousel` 20px gap
 }
 
 #carousel figure {
+  margin: 0;
   display: block;
   position: absolute;
   width: 186px;
@@ -136,4 +137,3 @@ And you're absolutely right. The repetitive nature of 3D objects lend themselves
 * * *
 
 [**Next: Conclusion &raquo;**](conclusion.html)
-


### PR DESCRIPTION
Apparently figure elements gets these properties set by default, which creates a margin:

```
-webkit-margin-before
-webkit-margin-after
-webkit-margin-start
-webkit-margin-end
```

Setting margin to 0 overrides that behaviour and the examples behave nicely.
