### PR TITLE
Add un-prefixed @keyframes spinCube declaration

### DIFF
--- a/_posts/examples/2010-12-01-perspective-03.html
+++ b/_posts/examples/2010-12-01-perspective-03.html
@@ -49,6 +49,11 @@ category: examples
       100% { -moz-transform: translateZ( -100px ) rotateX( 360deg ) rotateY( 360deg ); }
     }
 
+    @keyframes spinCube {
+        0% { transform: translateZ( -100px ) rotateX(   0deg ) rotateY(   0deg ); }
+      100% { transform: translateZ( -100px ) rotateX( 360deg ) rotateY( 360deg ); }
+    }
+
     #cube figure {
       display: block;
       position: absolute;


### PR DESCRIPTION
Hi David! With this change the spinning cube example will work on current browsers. Cheers!
